### PR TITLE
Added `customizeContext` and `customizeRendering` functions to discon…

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-react-hooks": "^4.0.2",
     "express": "^4.17.1",
     "graphql.macro": "^1.4.2",
+    "js-yaml": "^3.13.1",
     "next-offline": "^5.0.0",
     "next-plugin-graphql": "0.0.2",
     "npm-run-all": "^4.1.5",


### PR DESCRIPTION
…nected mode middleware to allow for customizing the context data for a given route and for facilitating Uniform personalization testing in disconnected mode.